### PR TITLE
Dropping no longer supported parameter

### DIFF
--- a/rabbitr.rb
+++ b/rabbitr.rb
@@ -6,7 +6,6 @@ class Rabbitr < Formula
   desc "rabbitr - CLI tool for RabbitMQ management"
   homepage "https://github.com/smartrecruiters/rabbitr"
   version "1.3.2"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/smartrecruiters/rabbitr/releases/download/1.3.2/rabbitr_1.3.2_darwin_amd64.tar.gz"


### PR DESCRIPTION
## Description
Dropping ` bottle :unneeded` switch as it is no longer supported

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the smartrecruiters/public-homebrew-taps tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/smartrecruiters/homebrew-public-homebrew-taps/rabbitr.rb:9
```